### PR TITLE
Add browser base64 encoding support.

### DIFF
--- a/pnglib.js
+++ b/pnglib.js
@@ -140,6 +140,13 @@
 
 			var s = this.getDump();
 
+			// If the current browser supports the Base64 encoding
+			// function, then offload the that to the browser as it
+			// will be done in native code.
+			if ((typeof window.btoa !== 'undefined') && (window.btoa !== null)) {
+				return window.btoa(s);
+			}
+
 			var ch = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
 			var c1, c2, c3, e1, e2, e3, e4;
 			var l = s.length;


### PR DESCRIPTION
If the browser supports native base64 encoding, then offload the encoding to the browser as it will do this in native code.

When this library was created IE didn't support native base64 encoding, so it's understandable that it wasn't used; but now all major browsers support the `window.btoa(..)` function.

**Chrome** all versions
**Safari** all versions
**Opera** all versions
**Firefox** version 1.0+
**IE** version 10+
**Edge** all versions

[http://www.w3schools.com/jsref/met_win_btoa.asp](http://www.w3schools.com/jsref/met_win_btoa.asp)